### PR TITLE
TIP-603: Allow possibility to export the products with all attribute keys possible

### DIFF
--- a/AttributeKeyProvider.php
+++ b/AttributeKeyProvider.php
@@ -6,12 +6,13 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\CurrencyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 
 /**
- * Generate the list of attribute keys for a given attribute. The keys are sorted so that we always get
+ * Generate the list of attribute keys. The keys are sorted so that we always get
  * them in the same consistent order.
  *
  * @author    Philippe Mossiere <philippe.mossiere@akeneo.com>
@@ -21,6 +22,9 @@ use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 class AttributeKeyProvider
 {
     const METRIC_UNIT = 'unit';
+
+    /** @var AttributeRepositoryInterface */
+    private $attributeRepository;
 
     /** @var ChannelRepositoryInterface */
     private $channelRepository;
@@ -43,15 +47,18 @@ class AttributeKeyProvider
     /**
      * ProductValueRawBuilder constructor.
      *
-     * @param ChannelRepositoryInterface  $channelRepository
-     * @param LocaleRepositoryInterface   $localeRepository
-     * @param CurrencyRepositoryInterface $currencyRepository
+     * @param AttributeRepositoryInterface $attributeRepository
+     * @param ChannelRepositoryInterface   $channelRepository
+     * @param LocaleRepositoryInterface    $localeRepository
+     * @param CurrencyRepositoryInterface  $currencyRepository
      */
     public function __construct(
+        AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
         LocaleRepositoryInterface $localeRepository,
         CurrencyRepositoryInterface $currencyRepository
     ) {
+        $this->attributeRepository = $attributeRepository;
         $this->channelRepository = $channelRepository;
         $this->localeRepository = $localeRepository;
         $this->currencyRepository = $currencyRepository;
@@ -105,6 +112,24 @@ class AttributeKeyProvider
                     $keys[] = $key . '-' .  self::METRIC_UNIT;
                 }
                 break;
+        }
+
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * Generate the list of attribute keys for all attributes. The keys are sorted so that we always get
+     * them in the same consistent order.
+     *
+     * @return array
+     */
+    public function getAllAttributesKeys()
+    {
+        $keys = [];
+        foreach ($this->attributeRepository->findAll() as $attribute) {
+            $keys = array_merge($keys, $this->getAttributeKeys($attribute));
         }
 
         sort($keys);

--- a/AttributeKeyProvider.php
+++ b/AttributeKeyProvider.php
@@ -11,7 +11,10 @@ use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 
 /**
- * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * Generate the list of attribute keys for a given attribute. The keys are sorted so that we always get
+ * them in the same consistent order.
+ *
+ * @author    Philippe Mossiere <philippe.mossiere@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
@@ -55,7 +58,8 @@ class AttributeKeyProvider
     }
 
     /**
-     * Generate the list of attribute keys for a given attribute
+     * Generate the list of attribute keys for a given attribute. The keys are sorted so that we always get
+     * them in the same consistent order.
      *
      * Example:
      * Attribute: description localizable in english and french for ecommerce
@@ -102,6 +106,8 @@ class AttributeKeyProvider
                 }
                 break;
         }
+
+        sort($keys);
 
         return $keys;
     }

--- a/AttributeKeyProvider.php
+++ b/AttributeKeyProvider.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Pim\Bundle\DataGeneratorBundle;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\CurrencyInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+
+/**
+ * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class AttributeKeyProvider
+{
+    const METRIC_UNIT = 'unit';
+
+    /** @var ChannelRepositoryInterface */
+    private $channelRepository;
+
+    /** @var LocaleRepositoryInterface */
+    private $localeRepository;
+
+    /** @var CurrencyRepositoryInterface */
+    private $currencyRepository;
+
+    /** @var ChannelInterface[] */
+    private $channels;
+
+    /** @var CurrencyInterface[] */
+    private $currencies;
+
+    /** @var LocaleInterface[] */
+    private $locales;
+
+    /**
+     * ProductValueRawBuilder constructor.
+     *
+     * @param ChannelRepositoryInterface  $channelRepository
+     * @param LocaleRepositoryInterface   $localeRepository
+     * @param CurrencyRepositoryInterface $currencyRepository
+     */
+    public function __construct(
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository,
+        CurrencyRepositoryInterface $currencyRepository
+    ) {
+        $this->channelRepository = $channelRepository;
+        $this->localeRepository = $localeRepository;
+        $this->currencyRepository = $currencyRepository;
+    }
+
+    /**
+     * Generate the list of attribute keys for a given attribute
+     *
+     * Example:
+     * Attribute: description localizable in english and french for ecommerce
+     * Attributes keys are:
+     * [ description-en_US-ecommerce, description-fr_FR-ecommerce ]
+     *
+     * @param AttributeInterface $attribute
+     *
+     * @return array
+     */
+    public function getAttributeKeys(AttributeInterface $attribute)
+    {
+        $keys = [];
+
+        $keys[$attribute->getCode()] = [];
+
+        $updatedKeys = [];
+        if ($attribute->isScopable() && $attribute->isLocalizable()) {
+            foreach ($this->getLocales() as $locale) {
+                foreach ($this->getChannels() as $channel) {
+                    foreach ($keys as $baseKey => $keyOptions) {
+                        $key               = $baseKey . '-' . $locale->getCode() . '-' . $channel->getCode();
+                        $updatedKeys[$key] = array_merge($keyOptions, ['locale' => $locale, 'channel' => $channel]);
+                    }
+                }
+            }
+            $keys = $updatedKeys;
+        } elseif ($attribute->isScopable() && !$attribute->isLocalizable()) {
+            foreach ($this->getChannels() as $channel) {
+                foreach ($keys as $baseKey => $keyOptions) {
+                    $key               = $baseKey . '-' . $channel->getCode();
+                    $updatedKeys[$key] = array_merge($keyOptions, ['channel' => $channel]);
+                }
+            }
+            $keys = $updatedKeys;
+        } elseif (!$attribute->isScopable() && $attribute->isLocalizable()) {
+            foreach ($this->getLocales() as $locale) {
+                foreach ($keys as $baseKey => $keyOptions) {
+                    $key               = $baseKey . '-' . $locale->getCode();
+                    $updatedKeys[$key] = array_merge($keyOptions, ['locale' => $locale]);
+                }
+            }
+            $keys = $updatedKeys;
+        }
+
+        switch ($attribute->getBackendType()) {
+            case 'prices':
+                $updatedKeys = [];
+
+                foreach ($keys as $key => $keyOptions) {
+                    foreach ($this->getCurrencies() as $currency) {
+                        $updatedKeys[$key . '-' . $currency->getCode()] = array_merge(
+                            $keyOptions,
+                            ['currency' => $currency]
+                        );
+                    }
+                }
+                $keys = $updatedKeys;
+                break;
+            case 'metric':
+                $updatedKeys = [];
+
+                foreach ($keys as $key => $keyOptions) {
+                    $updatedKeys[$key]                           = $keyOptions;
+                    $updatedKeys[$key . '-' . self::METRIC_UNIT] = $keyOptions;
+                }
+                $keys = $updatedKeys;
+                break;
+        }
+
+        $enabledKeys = [];
+        foreach ($keys as $key => $keyOptions) {
+            if ($this->isAttributeKeyValid($keyOptions)) {
+                $enabledKeys[] = $key;
+            }
+        }
+
+        return $enabledKeys;
+    }
+
+    /**
+     * Get all channels
+     *
+     * @return ChannelInterface[]
+     */
+    private function getChannels()
+    {
+        if (null === $this->channels) {
+            $this->channels = [];
+            $channels       = $this->channelRepository->findAll();
+            foreach ($channels as $channel) {
+                $this->channels[$channel->getCode()] = $channel;
+            }
+        }
+
+        return $this->channels;
+    }
+
+    /**
+     * Get active currencies
+     *
+     * @return CurrencyInterface[]
+     */
+    private function getCurrencies()
+    {
+        if (null === $this->currencies) {
+            $this->currencies = [];
+            $currencies       = $this->currencyRepository->findBy(['activated' => 1]);
+            foreach ($currencies as $currency) {
+                $this->currencies[$currency->getCode()] = $currency;
+            }
+        }
+
+        return $this->currencies;
+    }
+
+    /**
+     * Get active locales
+     *
+     * @return LocaleInterface[]
+     */
+    private function getLocales()
+    {
+        if (null === $this->locales) {
+            $this->locales = [];
+            $locales       = $this->localeRepository->findBy(['activated' => 1]);
+            foreach ($locales as $locale) {
+                $this->locales[$locale->getCode()] = $locale;
+            }
+        }
+
+        return $this->locales;
+    }
+
+
+    /**
+     * Returns true if the key is valid, according to channels locale and currency.
+     *
+     * @param $options
+     *
+     * @return bool
+     */
+    private function isAttributeKeyValid(array $options)
+    {
+        if (isset($options['channel'])) {
+            $channel = $options['channel'];
+
+            if (isset($options['locale']) && !$this->hasChannelLocale($channel, $options['locale'])) {
+                return false;
+            }
+
+            if (isset($options['currency']) && !$this->hasChannelCurrency($channel, $options['currency'])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if channel has activated locale.
+     *
+     * @param ChannelInterface $channel
+     * @param LocaleInterface  $locale
+     *
+     * @return bool
+     */
+    private function hasChannelLocale(ChannelInterface $channel, LocaleInterface $locale)
+    {
+        foreach ($channel->getLocaleCodes() as $availableLocale) {
+            if ($locale->getCode() === $availableLocale) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if channel has activated currency.
+     *
+     * @param ChannelInterface  $channel
+     * @param CurrencyInterface $currency
+     *
+     * @return bool
+     */
+    private function hasChannelCurrency(ChannelInterface $channel, CurrencyInterface $currency)
+    {
+        foreach ($channel->getCurrencies() as $availableCurrency) {
+            if ($currency->getCode() === $availableCurrency->getCode()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/DependencyInjection/Configuration/ProductGeneratorConfiguration.php
+++ b/DependencyInjection/Configuration/ProductGeneratorConfiguration.php
@@ -31,6 +31,7 @@ class ProductGeneratorConfiguration implements ConfigurationInterface
                 ->integerNode('categories_count')->min(0)->defaultValue(0)->info('Number of categories per product')->end()
                 ->integerNode('products_per_variant_group')->min(0)->defaultValue(0)->info('Number of products in each variant group')->end()
                 ->integerNode('percentage_complete')->min(0)->max(100)->defaultValue(20)->info('Percentage of complete products')->end()
+                ->booleanNode('all_attribute_keys')->defaultFalse()->info('If true exports the products with all attribute keys possible')->end()
             ->end();
 
         $draftsNode = $this->getDraftAndProductBaseNode('product_drafts');

--- a/Generator/ProductGenerator.php
+++ b/Generator/ProductGenerator.php
@@ -29,9 +29,6 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
     /** @var VariantGroupDataProvider[] */
     private $variantGroupDataProviders = [];
 
-    /** @var AttributeRepositoryInterface */
-    private $attributeRepository;
-
     /** @var AttributeKeyProvider */
     private $attributeKeyProvider;
 
@@ -39,20 +36,17 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
      * @param ProductRawBuilder            $productRawBuilder
      * @param FamilyRepositoryInterface    $familyRepository
      * @param GroupRepositoryInterface     $groupRepository
-     * @param AttributeRepositoryInterface $attributeRepository
      * @param AttributeKeyProvider         $attributeKeyProvider
      */
     public function __construct(
         ProductRawBuilder $productRawBuilder,
         FamilyRepositoryInterface $familyRepository,
         GroupRepositoryInterface $groupRepository,
-        AttributeRepositoryInterface $attributeRepository,
         AttributeKeyProvider $attributeKeyProvider
     ) {
         parent::__construct($productRawBuilder, $familyRepository);
         $this->groupRepository = $groupRepository;
         $this->variantGroupDataProviders = [];
-        $this->attributeRepository = $attributeRepository;
         $this->attributeKeyProvider = $attributeKeyProvider;
     }
 
@@ -133,8 +127,9 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
         }
 
         if (true === $allAttributeKeys) {
-            $this->headers = array_unique(array_merge($this->getCompleteHeaderList(), $this->headers));
-            sort($this->headers);
+            $keys = array_unique(array_merge($this->attributeKeyProvider->getAllAttributesKeys(), $this->headers));
+            sort($keys);
+            $this->headers = $keys;
         }
 
         $this->writeCsvFile($this->headers, $outputFile, $tmpFile, $delimiter);
@@ -165,21 +160,6 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
         }
 
         return $variantGroupProvider;
-    }
-
-    /**
-     * Return all the possible attribute keys of the catalog.
-     *
-     * @return array
-     */
-    private function getCompleteHeaderList()
-    {
-        $keys = [];
-        foreach ($this->attributeRepository->findAll() as $attribute) {
-            $keys = array_merge($keys, $this->attributeKeyProvider->getAttributeKeys($attribute));
-        }
-
-        return $keys;
     }
 
     /**

--- a/Generator/ProductGenerator.php
+++ b/Generator/ProductGenerator.php
@@ -175,7 +175,7 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
     private function getCompleteHeaderList()
     {
         $keys = [];
-        foreach ($this->attributeRepository->findBy([], ['code' => 'ASC']) as $attribute) {
+        foreach ($this->attributeRepository->findAll() as $attribute) {
             $keys = array_merge($keys, $this->attributeKeyProvider->getAttributeKeys($attribute));
         }
 

--- a/Generator/ProductGenerator.php
+++ b/Generator/ProductGenerator.php
@@ -3,9 +3,11 @@
 namespace Pim\Bundle\DataGeneratorBundle\Generator;
 
 use Faker;
+use Pim\Bundle\DataGeneratorBundle\AttributeKeyProvider;
 use Pim\Bundle\DataGeneratorBundle\Generator\Product\AbstractProductGenerator;
 use Pim\Bundle\DataGeneratorBundle\Generator\Product\ProductRawBuilder;
 use Pim\Bundle\DataGeneratorBundle\VariantGroupDataProvider;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
 use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -27,19 +29,31 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
     /** @var VariantGroupDataProvider[] */
     private $variantGroupDataProviders = [];
 
+    /** @var AttributeRepositoryInterface */
+    private $attributeRepository;
+
+    /** @var AttributeKeyProvider */
+    private $attributeKeyProvider;
+
     /**
      * @param ProductRawBuilder            $productRawBuilder
      * @param FamilyRepositoryInterface    $familyRepository
      * @param GroupRepositoryInterface     $groupRepository
+     * @param AttributeRepositoryInterface $attributeRepository
+     * @param AttributeKeyProvider         $attributeKeyProvider
      */
     public function __construct(
         ProductRawBuilder $productRawBuilder,
         FamilyRepositoryInterface $familyRepository,
-        GroupRepositoryInterface $groupRepository
+        GroupRepositoryInterface $groupRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeKeyProvider $attributeKeyProvider
     ) {
         parent::__construct($productRawBuilder, $familyRepository);
         $this->groupRepository = $groupRepository;
         $this->variantGroupDataProviders = [];
+        $this->attributeRepository = $attributeRepository;
+        $this->attributeKeyProvider = $attributeKeyProvider;
     }
 
     /**
@@ -61,6 +75,7 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
         $forcedValues        = $entitiesConfig['force_values'];
         $delimiter           = $entitiesConfig['delimiter'];
         $percentageComplete  = $entitiesConfig['percentage_complete'];
+        $allAttributeKeys    = $entitiesConfig['all_attribute_keys'];
 
         if ($variantGroupCount > 0) {
             foreach ($this->groupRepository->getAllVariantGroups() as $variantGroup) {
@@ -117,6 +132,11 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
             $progress->advance();
         }
 
+        if (true === $allAttributeKeys) {
+            $this->headers = array_unique(array_merge($this->getCompleteHeaderList(), $this->headers));
+            sort($this->headers);
+        }
+
         $this->writeCsvFile($this->headers, $outputFile, $tmpFile, $delimiter);
         unlink($tmpFile);
 
@@ -145,6 +165,21 @@ class ProductGenerator extends AbstractProductGenerator implements GeneratorInte
         }
 
         return $variantGroupProvider;
+    }
+
+    /**
+     * Return all the possible attribute keys of the catalog.
+     *
+     * @return array
+     */
+    private function getCompleteHeaderList()
+    {
+        $keys = [];
+        foreach ($this->attributeRepository->findBy([], ['code' => 'ASC']) as $attribute) {
+            $keys = array_merge($keys, $this->attributeKeyProvider->getAttributeKeys($attribute));
+        }
+
+        return $keys;
     }
 
     /**

--- a/Resources/config/generators.yml
+++ b/Resources/config/generators.yml
@@ -113,6 +113,8 @@ services:
             - '@pim_data_generator.product.product_raw_builder'
             - '@pim_catalog.repository.family'
             - '@pim_catalog.repository.group'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_data_generator.attribute_key_provider'
         tags:
             - { name: pim_data_generator.generator }
 

--- a/Resources/config/generators.yml
+++ b/Resources/config/generators.yml
@@ -113,7 +113,6 @@ services:
             - '@pim_data_generator.product.product_raw_builder'
             - '@pim_catalog.repository.family'
             - '@pim_catalog.repository.group'
-            - '@pim_catalog.repository.attribute'
             - '@pim_data_generator.attribute_key_provider'
         tags:
             - { name: pim_data_generator.generator }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,10 +1,15 @@
 services:
-    pim_data_generator.product.product_value_raw_builder:
-        class: 'Pim\Bundle\DataGeneratorBundle\Generator\Product\ProductValueRawBuilder'
+    pim_data_generator.attribute_key_provider:
+        class: 'Pim\Bundle\DataGeneratorBundle\AttributeKeyProvider'
         arguments:
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.currency'
+
+    pim_data_generator.product.product_value_raw_builder:
+        class: 'Pim\Bundle\DataGeneratorBundle\Generator\Product\ProductValueRawBuilder'
+        arguments:
+            - '@pim_data_generator.attribute_key_provider'
 
     pim_data_generator.product.product_raw_builder:
         class: 'Pim\Bundle\DataGeneratorBundle\Generator\Product\ProductRawBuilder'
@@ -15,3 +20,4 @@ services:
 
     pim_data_generator.generator.registry:
         class: 'Pim\Bundle\DataGeneratorBundle\Generator\GeneratorRegistry'
+

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,6 +2,7 @@ services:
     pim_data_generator.attribute_key_provider:
         class: 'Pim\Bundle\DataGeneratorBundle\AttributeKeyProvider'
         arguments:
+            - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.currency'

--- a/spec/Pim/Bundle/DataGeneratorBundle/AttributeKeyProviderSpec.php
+++ b/spec/Pim/Bundle/DataGeneratorBundle/AttributeKeyProviderSpec.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace spec\Pim\Bundle\DataGeneratorBundle;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\CurrencyInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+
+class AttributeKeyProviderSpec extends ObjectBehavior
+{
+    function let(
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository,
+        CurrencyRepositoryInterface $currencyRepository,
+        ChannelInterface $ecommerce,
+        ChannelInterface $print,
+        LocaleInterface $en,
+        LocaleInterface $fr,
+        LocaleInterface $de,
+        ArrayCollection $ecommerceLocales,
+        ArrayCollection $printLocales,
+        CurrencyInterface $euro,
+        CurrencyInterface $dollar
+    ) {
+        $currencyRepository->findBy(["activated" => 1])->willReturn([$euro, $dollar]);
+
+        $euro->getCode()->willReturn('eur');
+        $dollar->getCode()->willReturn('usd');
+
+        $ecommerceLocales->toArray()->willReturn([$en, $fr, $de]);
+        $printLocales->toArray()->willReturn([$en]);
+
+        $ecommerce->getLocales()->willReturn($ecommerceLocales);
+        $print->getLocales()->willReturn($printLocales);
+
+        $localeRepository->findBy(["activated" => 1])->willReturn([$en, $fr, $de]);
+
+        $en->getCode()->willReturn('en_US');
+        $fr->getCode()->willReturn('fr_FR');
+        $de->getCode()->willReturn('de_DE');
+
+        $channelRepository->findAll()->willReturn([$ecommerce, $print]);
+
+        $ecommerce->getCode()->willReturn('ecommerce');
+        $print->getCode()->willReturn('print');
+
+        $this->beConstructedWith($channelRepository, $localeRepository, $currencyRepository);
+    }
+
+    function it_provides_keys_for_simple_attribute(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attr');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+        $attribute->getBackendType()->willReturn('text');
+
+        $this->getAttributeKeys($attribute)->shouldReturn([
+            'attr',
+        ]);
+    }
+
+    function it_provides_keys_for_scopable_attribute(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attr');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+        $attribute->getBackendType()->willReturn('text');
+
+        $this->getAttributeKeys($attribute)->shouldReturn([
+            'attr-ecommerce',
+            'attr-print',
+        ]);
+    }
+
+    function it_provides_keys_for_localizable_attribute(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attr');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->isLocaleSpecific()->willReturn(false);
+        $attribute->getBackendType()->willReturn('text');
+
+        $this->getAttributeKeys($attribute)->shouldReturn([
+            'attr-en_US',
+            'attr-fr_FR',
+            'attr-de_DE',
+        ]);
+    }
+
+    function it_provides_keys_for_scopable_and_localizable_attribute(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attr');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->isLocaleSpecific()->willReturn(false);
+        $attribute->getBackendType()->willReturn('text');
+
+        $this->getAttributeKeys($attribute)->shouldReturn([
+            'attr-en_US-ecommerce',
+            'attr-fr_FR-ecommerce',
+            'attr-de_DE-ecommerce',
+            'attr-en_US-print',
+        ]);
+    }
+
+    function it_provides_keys_for_scopable_metric(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attr');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+        $attribute->getBackendType()->willReturn('metric');
+
+        $this->getAttributeKeys($attribute)->shouldReturn([
+            'attr-ecommerce',
+            'attr-print',
+            'attr-ecommerce-unit',
+            'attr-print-unit',
+        ]);
+    }
+
+    function it_provides_keys_for_localizable_prices(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attr');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->isLocaleSpecific()->willReturn(false);
+        $attribute->getBackendType()->willReturn('prices');
+
+        $this->getAttributeKeys($attribute)->shouldHaveAttributeKeys([
+            'attr-en_US-eur',
+            'attr-en_US-usd',
+            'attr-fr_FR-eur',
+            'attr-fr_FR-usd',
+            'attr-de_DE-eur',
+            'attr-de_DE-usd',
+        ]);
+    }
+
+    function it_provides_keys_for_scopable_and_specific_localizable_prices(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attr');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->isLocaleSpecific()->willReturn(true);
+        $attribute->getLocaleSpecificCodes()->willReturn(['en_US']);
+
+        $attribute->getBackendType()->willReturn('prices');
+
+        $this->getAttributeKeys($attribute)->shouldHaveAttributeKeys([
+            'attr-en_US-ecommerce-eur',
+            'attr-en_US-ecommerce-usd',
+            'attr-en_US-print-eur',
+            'attr-en_US-print-usd',
+        ]);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveAttributeKeys' => function ($result, $expected) {
+                return count($result) && count($expected) &&
+                    [] === array_diff($result, $expected) &&
+                    [] === array_diff($expected, $result);
+            },
+        ];
+    }
+}

--- a/spec/Pim/Bundle/DataGeneratorBundle/AttributeKeyProviderSpec.php
+++ b/spec/Pim/Bundle/DataGeneratorBundle/AttributeKeyProviderSpec.php
@@ -89,9 +89,9 @@ class AttributeKeyProviderSpec extends ObjectBehavior
         $attribute->getBackendType()->willReturn('text');
 
         $this->getAttributeKeys($attribute)->shouldReturn([
+            'attr-de_DE',
             'attr-en_US',
             'attr-fr_FR',
-            'attr-de_DE',
         ]);
     }
 
@@ -104,10 +104,10 @@ class AttributeKeyProviderSpec extends ObjectBehavior
         $attribute->getBackendType()->willReturn('text');
 
         $this->getAttributeKeys($attribute)->shouldReturn([
-            'attr-en_US-ecommerce',
-            'attr-fr_FR-ecommerce',
             'attr-de_DE-ecommerce',
+            'attr-en_US-ecommerce',
             'attr-en_US-print',
+            'attr-fr_FR-ecommerce',
         ]);
     }
 
@@ -121,8 +121,8 @@ class AttributeKeyProviderSpec extends ObjectBehavior
 
         $this->getAttributeKeys($attribute)->shouldReturn([
             'attr-ecommerce',
-            'attr-print',
             'attr-ecommerce-unit',
+            'attr-print',
             'attr-print-unit',
         ]);
     }
@@ -136,12 +136,12 @@ class AttributeKeyProviderSpec extends ObjectBehavior
         $attribute->getBackendType()->willReturn('prices');
 
         $this->getAttributeKeys($attribute)->shouldHaveAttributeKeys([
+            'attr-de_DE-eur',
+            'attr-de_DE-usd',
             'attr-en_US-eur',
             'attr-en_US-usd',
             'attr-fr_FR-eur',
             'attr-fr_FR-usd',
-            'attr-de_DE-eur',
-            'attr-de_DE-usd',
         ]);
     }
 

--- a/spec/Pim/Bundle/DataGeneratorBundle/AttributeKeyProviderSpec.php
+++ b/spec/Pim/Bundle/DataGeneratorBundle/AttributeKeyProviderSpec.php
@@ -8,6 +8,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\CurrencyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
@@ -15,6 +16,7 @@ use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 class AttributeKeyProviderSpec extends ObjectBehavior
 {
     function let(
+        AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
         LocaleRepositoryInterface $localeRepository,
         CurrencyRepositoryInterface $currencyRepository,
@@ -50,7 +52,7 @@ class AttributeKeyProviderSpec extends ObjectBehavior
         $ecommerce->getCode()->willReturn('ecommerce');
         $print->getCode()->willReturn('print');
 
-        $this->beConstructedWith($channelRepository, $localeRepository, $currencyRepository);
+        $this->beConstructedWith($attributeRepository, $channelRepository, $localeRepository, $currencyRepository);
     }
 
     function it_provides_keys_for_simple_attribute(AttributeInterface $attribute)
@@ -160,6 +162,34 @@ class AttributeKeyProviderSpec extends ObjectBehavior
             'attr-en_US-ecommerce-usd',
             'attr-en_US-print-eur',
             'attr-en_US-print-usd',
+        ]);
+    }
+
+    function it_provides_the_keys_of_all_attributes(
+        $attributeRepository,
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2
+    ) {
+        $attributeRepository->findAll()->willReturn([$attribute1, $attribute2]);
+
+        $attribute1->getCode()->willReturn('name');
+        $attribute1->isScopable()->willReturn(false);
+        $attribute1->isLocalizable()->willReturn(false);
+        $attribute1->isLocaleSpecific()->willReturn(false);
+        $attribute1->getBackendType()->willReturn('text');
+
+        $attribute2->getCode()->willReturn('description');
+        $attribute2->isScopable()->willReturn(true);
+        $attribute2->isLocalizable()->willReturn(true);
+        $attribute2->isLocaleSpecific()->willReturn(false);
+        $attribute2->getBackendType()->willReturn('text');
+
+        $this->getAllAttributesKeys()->shouldReturn([
+            'description-de_DE-ecommerce',
+            'description-en_US-ecommerce',
+            'description-en_US-print',
+            'description-fr_FR-ecommerce',
+            'name',
         ]);
     }
 

--- a/spec/Pim/Bundle/DataGeneratorBundle/Generator/ProductGeneratorSpec.php
+++ b/spec/Pim/Bundle/DataGeneratorBundle/Generator/ProductGeneratorSpec.php
@@ -19,10 +19,9 @@ class ProductGeneratorSpec extends ObjectBehavior
         ProductRawBuilder $rawBuilder,
         FamilyRepositoryInterface $familyRepo,
         GroupRepositoryInterface $groupRepo,
-        AttributeRepositoryInterface $attributeRepository,
         AttributeKeyProvider $attributeKeyProvider
     ) {
-        $this->beConstructedWith($rawBuilder, $familyRepo, $groupRepo, $attributeRepository, $attributeKeyProvider);
+        $this->beConstructedWith($rawBuilder, $familyRepo, $groupRepo, $attributeKeyProvider);
     }
 
     function it_is_initializable()
@@ -83,12 +82,9 @@ class ProductGeneratorSpec extends ObjectBehavior
     function it_generates_products_with_all_attribute_keys(
         $rawBuilder,
         $familyRepo,
-        $attributeRepository,
         $attributeKeyProvider,
         ProgressBar $progress,
-        FamilyInterface $family,
-        AttributeInterface $attribute1,
-        AttributeInterface $attribute2
+        FamilyInterface $family
     ) {
         $globalConfig = ['output_dir' => '/tmp/', 'seed' => 123456789];
         $entitiesConfig = [
@@ -119,27 +115,7 @@ class ProductGeneratorSpec extends ObjectBehavior
         $rawBuilder->fillInRandomCategories($raw, 0)->willReturn(null);
         $rawBuilder->fillInRandomAttributes($family, $raw, [], 1, 0)->willReturn(null);
         $rawBuilder->fillInMandatoryAttributes($family, $raw, [], [])->willReturn(null);
-        $attributeRepository->findAll()->willReturn(
-            [
-                $attribute1,
-                $attribute2
-            ]
-        );
-        $attributeKeyProvider->getAttributeKeys($attribute1)
-            ->shouldBeCalled()
-            ->willReturn(
-                [
-                    'attribute1-en_US',
-                    'attribute1-fr_FR',
-                ]
-            );
-        $attributeKeyProvider->getAttributeKeys($attribute2)
-            ->shouldBeCalled()
-            ->willReturn(
-                [
-                    'attribute2-en_US-ecommerce',
-                ]
-            );
+        $attributeKeyProvider->getAllAttributesKeys()->shouldBeCalled()->willReturn([]);
 
         $this->generate($globalConfig, $entitiesConfig, $progress, $options);
     }

--- a/spec/Pim/Bundle/DataGeneratorBundle/Generator/ProductGeneratorSpec.php
+++ b/spec/Pim/Bundle/DataGeneratorBundle/Generator/ProductGeneratorSpec.php
@@ -3,8 +3,11 @@
 namespace spec\Pim\Bundle\DataGeneratorBundle\Generator;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\DataGeneratorBundle\AttributeKeyProvider;
 use Pim\Bundle\DataGeneratorBundle\Generator\Product\ProductRawBuilder;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
 use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
 use Prophecy\Argument;
@@ -15,9 +18,11 @@ class ProductGeneratorSpec extends ObjectBehavior
     function let(
         ProductRawBuilder $rawBuilder,
         FamilyRepositoryInterface $familyRepo,
-        GroupRepositoryInterface $groupRepo
+        GroupRepositoryInterface $groupRepo,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeKeyProvider $attributeKeyProvider
     ) {
-        $this->beConstructedWith($rawBuilder, $familyRepo, $groupRepo);
+        $this->beConstructedWith($rawBuilder, $familyRepo, $groupRepo, $attributeRepository, $attributeKeyProvider);
     }
 
     function it_is_initializable()
@@ -55,6 +60,7 @@ class ProductGeneratorSpec extends ObjectBehavior
             'percentage_complete' => 0,
             'filename' => 'product_draft.csv',
             'delimiter' => ';',
+            'all_attribute_keys' => false
         ];
         $options = [];
         $raw = [
@@ -70,6 +76,70 @@ class ProductGeneratorSpec extends ObjectBehavior
         $rawBuilder->fillInRandomCategories($raw, 0)->willReturn(null);
         $rawBuilder->fillInRandomAttributes($family, $raw, [], 1, 0)->willReturn(null);
         $rawBuilder->fillInMandatoryAttributes($family, $raw, [], [])->willReturn(null);
+
+        $this->generate($globalConfig, $entitiesConfig, $progress, $options);
+    }
+
+    function it_generates_products_with_all_attribute_keys(
+        $rawBuilder,
+        $familyRepo,
+        $attributeRepository,
+        $attributeKeyProvider,
+        ProgressBar $progress,
+        FamilyInterface $family,
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2
+    ) {
+        $globalConfig = ['output_dir' => '/tmp/', 'seed' => 123456789];
+        $entitiesConfig = [
+            'count' => 1,
+            'filled_attributes_count' => 1,
+            'filled_attributes_standard_deviation' => 0,
+            'start_index' => 0,
+            'categories_count' => 0,
+            'products_per_variant_group' => 0,
+            'mandatory_attributes' => [],
+            'force_values' => [],
+            'percentage_complete' => 0,
+            'filename' => 'product_draft.csv',
+            'delimiter' => ';',
+            'all_attribute_keys' => true
+        ];
+        $options = [];
+        $raw = [
+            'sku'    => 'id-0',
+            'family' => 'family_code',
+            'groups' => '',
+        ];
+
+        $familyRepo->findAll()->willReturn([$family]);
+        $family->getCode()->willReturn('family_code');
+        $rawBuilder->buildBaseProduct($family, 'id-0', '')->willReturn($raw);
+        $rawBuilder->setFakerGenerator(Argument::any())->willReturn(null);
+        $rawBuilder->fillInRandomCategories($raw, 0)->willReturn(null);
+        $rawBuilder->fillInRandomAttributes($family, $raw, [], 1, 0)->willReturn(null);
+        $rawBuilder->fillInMandatoryAttributes($family, $raw, [], [])->willReturn(null);
+        $attributeRepository->findBy(Argument::cetera())->willReturn(
+            [
+                $attribute1,
+                $attribute2
+            ]
+        );
+        $attributeKeyProvider->getAttributeKeys($attribute1)
+            ->shouldBeCalled()
+            ->willReturn(
+                [
+                    'attribute1-en_US',
+                    'attribute1-fr_FR',
+                ]
+            );
+        $attributeKeyProvider->getAttributeKeys($attribute2)
+            ->shouldBeCalled()
+            ->willReturn(
+                [
+                    'attribute2-en_US-ecommerce',
+                ]
+            );
 
         $this->generate($globalConfig, $entitiesConfig, $progress, $options);
     }

--- a/spec/Pim/Bundle/DataGeneratorBundle/Generator/ProductGeneratorSpec.php
+++ b/spec/Pim/Bundle/DataGeneratorBundle/Generator/ProductGeneratorSpec.php
@@ -119,7 +119,7 @@ class ProductGeneratorSpec extends ObjectBehavior
         $rawBuilder->fillInRandomCategories($raw, 0)->willReturn(null);
         $rawBuilder->fillInRandomAttributes($family, $raw, [], 1, 0)->willReturn(null);
         $rawBuilder->fillInMandatoryAttributes($family, $raw, [], [])->willReturn(null);
-        $attributeRepository->findBy(Argument::cetera())->willReturn(
+        $attributeRepository->findAll()->willReturn(
             [
                 $attribute1,
                 $attribute2


### PR DESCRIPTION
What's done here:
- extraction of the logic that generate attribute keys into a dedicated `AttributeKeyProvider` class. This class has been simplified, rewritten and speced
- add an option to be able to export the products with all attribute keys possible

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Generate fixtures and install     | N
| Generate products and import      | N
| Review and 2 GTM                  | Y
| Tech Doc                          |

